### PR TITLE
Adapt recipes to hpx and kokkos sender-receiver compilation fixes

### DIFF
--- a/packages/hpx/fix_nvcc_sender_receiver.patch
+++ b/packages/hpx/fix_nvcc_sender_receiver.patch
@@ -1,0 +1,53 @@
+diff --git a/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp b/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
+index 6088f7ff98..7c896468a8 100644
+--- a/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
++++ b/libs/core/execution/include/hpx/execution/algorithms/detail/partial_algorithm.hpp
+@@ -27,7 +27,7 @@ namespace hpx::execution::experimental::detail {
+     struct partial_algorithm_base<Tag, hpx::util::index_pack<Is...>, Ts...>
+     {
+     private:
+-        HPX_NO_UNIQUE_ADDRESS hpx::util::member_pack_for<Ts...> ts;
++        HPX_NO_UNIQUE_ADDRESS hpx::util::member_pack_for<std::decay_t<Ts>...> ts;
+ 
+     public:
+         template <typename... Us>
+diff --git a/libs/core/execution/include/hpx/execution/algorithms/split.hpp b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+index 03a22fb4da..10f1355816 100644
+--- a/libs/core/execution/include/hpx/execution/algorithms/split.hpp
++++ b/libs/core/execution/include/hpx/execution/algorithms/split.hpp
+@@ -57,7 +57,7 @@ namespace hpx::execution::experimental {
+         template <typename Receiver>
+         struct error_visitor
+         {
+-            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
++            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver>& receiver;
+ 
+             template <typename Error>
+             void operator()(Error const& error) noexcept
+@@ -71,7 +71,7 @@ namespace hpx::execution::experimental {
+         template <typename Receiver>
+         struct value_visitor
+         {
+-            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
++            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver>& receiver;
+ 
+             template <typename Ts>
+             void operator()(Ts const& ts) noexcept
+@@ -286,15 +286,13 @@ namespace hpx::execution::experimental {
+ 
+                     void operator()(error_type const& error)
+                     {
+-                        hpx::visit(error_visitor<Receiver>{HPX_FORWARD(
+-                                       Receiver, receiver)},
++                        hpx::visit(error_visitor<Receiver>{receiver},
+                             error);
+                     }
+ 
+                     void operator()(value_type const& ts)
+                     {
+-                        hpx::visit(value_visitor<Receiver>{HPX_FORWARD(
+-                                       Receiver, receiver)},
++                        hpx::visit(value_visitor<Receiver>{receiver},
+                             ts);
+                     }
+                 };

--- a/packages/hpx/package.py
+++ b/packages/hpx/package.py
@@ -105,6 +105,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
             description=("GPU futures become synchronous. Disabling this option significantly "
                          "decreases GPU performance - this only intended for performance experiments!!"))
     patch("disable_async_gpu_futures.patch", when="@1.9.1: ~async_gpu_futures")
+    patch("fix_nvcc_sender_receiver.patch", when="@1.9.1: +cuda")
     variant("lci_pp_log", default=False,
             description="Enable the LCI-parcelport-specific logger.")
     variant("lci_pp_pcounter", default=False,

--- a/packages/hpx/package.py
+++ b/packages/hpx/package.py
@@ -105,7 +105,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
             description=("GPU futures become synchronous. Disabling this option significantly "
                          "decreases GPU performance - this only intended for performance experiments!!"))
     patch("disable_async_gpu_futures.patch", when="@1.9.1: ~async_gpu_futures")
-    patch("fix_nvcc_sender_receiver.patch", when="@1.9.1: +cuda")
+    patch("fix_nvcc_sender_receiver.patch", when="@1.9.0:1.9.1 +cuda %gcc")
     variant("lci_pp_log", default=False,
             description="Enable the LCI-parcelport-specific logger.")
     variant("lci_pp_pcounter", default=False,

--- a/packages/kokkos-nvcc-wrapper/package.py
+++ b/packages/kokkos-nvcc-wrapper/package.py
@@ -41,7 +41,8 @@ class KokkosNvccWrapper(Package):
 
     depends_on("cuda")
 
-    patch("adapt-kokkos-for-nix.patch")
+    # TODO is this required anymore?
+    # patch("adapt-kokkos-for-nix.patch")
 
     def install(self, spec, prefix):
         src = os.path.join("bin", "nvcc_wrapper")

--- a/packages/kokkos-nvcc-wrapper/package.py
+++ b/packages/kokkos-nvcc-wrapper/package.py
@@ -19,6 +19,11 @@ class KokkosNvccWrapper(Package):
 
     maintainers("Rombur")
 
+    version("4.3.01", sha256="5998b7c732664d6b5e219ccc445cd3077f0e3968b4be480c29cd194b4f45ec70")
+    version("4.3.00", sha256="53cf30d3b44dade51d48efefdaee7a6cf109a091b702a443a2eda63992e5fe0d")
+    version("4.2.01", sha256="cbabbabba021d00923fb357d2e1b905dda3838bd03c885a6752062fe03c67964")
+    version("4.2.00", sha256="ac08765848a0a6ac584a0a46cd12803f66dd2a2c2db99bb17c06ffc589bf5be8")
+    version("4.1.00", sha256="cf725ea34ba766fdaf29c884cfe2daacfdc6dc2d6af84042d1c78d0f16866275")
     version("4.0.01", sha256="bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0")
     version("4.0.00", sha256="1829a423883d4b44223c7c3a53d3c51671145aad57d7d23e6a1a4bebf710dcf6")
     version("3.7.02", sha256="5024979f06bc8da2fb696252a66297f3e0e67098595a0cc7345312b3b4aa0f54")
@@ -42,7 +47,7 @@ class KokkosNvccWrapper(Package):
     depends_on("cuda")
 
     # TODO is this required anymore?
-    # patch("adapt-kokkos-for-nix.patch")
+    patch("adapt-kokkos-for-nix.patch", when="@:4.1.00")
 
     def install(self, spec, prefix):
         src = os.path.join("bin", "nvcc_wrapper")

--- a/packages/kokkos/fix_nvcc_ctad.patch
+++ b/packages/kokkos/fix_nvcc_ctad.patch
@@ -1,0 +1,22 @@
+diff --git a/core/src/HPX/Kokkos_HPX.cpp b/core/src/HPX/Kokkos_HPX.cpp
+index 6d541a641..1f3d07834 100644
+--- a/core/src/HPX/Kokkos_HPX.cpp
++++ b/core/src/HPX/Kokkos_HPX.cpp
+@@ -153,7 +153,7 @@ void HPX::impl_instance_fence_locked(const std::string &name) const {
+         auto &s = impl_get_sender();
+ 
+         hpx::this_thread::experimental::sync_wait(std::move(s));
+-        s = hpx::execution::experimental::unique_any_sender(
++        s = hpx::execution::experimental::unique_any_sender<>(
+             hpx::execution::experimental::just());
+       });
+ }
+@@ -184,7 +184,7 @@ void HPX::impl_static_fence(const std::string &name) {
+         }
+ 
+         hpx::this_thread::experimental::sync_wait(std::move(s));
+-        s = hpx::execution::experimental::unique_any_sender(
++        s = hpx::execution::experimental::unique_any_sender<>(
+             hpx::execution::experimental::just());
+       });
+ }

--- a/packages/kokkos/package.py
+++ b/packages/kokkos/package.py
@@ -240,6 +240,8 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="cxxstd=17 ^cuda@:10")
     conflicts("+cuda", when="cxxstd=20 ^cuda@:11")
     conflicts("use_unsupported_sycl_arch=none intel_gpu_arch=none", when="sycl", msg="Need SYCL arch for +sycl build")
+    conflicts("@4.1.00: +hpx +cuda %gcc", when="^cuda@:12.2.0",
+              msg="Using +hpx and +cuda with gcc requires at least CUDA 12.3 due to compilation isuees")
 
     # SYCL and OpenMPTarget require C++17 or higher
     for cxxstdver in cxxstds[: cxxstds.index("17")]:
@@ -259,9 +261,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     # HPX version constraints
     depends_on("hpx@:1.6", when="@:3.5 +hpx")
     depends_on("hpx@1.7:", when="@3.6: +hpx")
+    depends_on("hpx@1.9:", when="@4.1: +hpx") # todo would 1.8 also work? 
 
     # Patches
-    patch("fix_nvcc_ctad.patch", when="@4.1.00: +hpx +cuda ")
+    patch("fix_nvcc_ctad.patch", when="@4.1.00:4.3.01 +hpx +cuda %gcc")
     patch("hpx_profiling_fences.patch", when="@3.5.00 +hpx")
     patch("sycl_bhalft_test.patch", when="@4.2.00 +sycl")
     # adds amd_gfx940 support to Kokkos 4.2.00 (upstreamed in https://github.com/kokkos/kokkos/pull/6671)

--- a/packages/kokkos/package.py
+++ b/packages/kokkos/package.py
@@ -251,6 +251,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("hpx@1.7:", when="@3.6: +hpx")
 
     # Patches
+    patch("fix_nvcc_ctad.patch", when="@4.1.00: +hpx +cuda ")
     patch("hpx_profiling_fences.patch", when="@3.5.00 +hpx")
     patch("sycl_bhalft_test.patch", when="@4.2.00 +sycl")
     # adds amd_gfx940 support to Kokkos 4.2.00 (upstreamed in https://github.com/kokkos/kokkos/pull/6671)

--- a/packages/octotiger/package.py
+++ b/packages/octotiger/package.py
@@ -168,9 +168,9 @@ class Octotiger(CMakePackage, CudaPackage, ROCmPackage):
     # Known conflicts
 
     # See issue https://github.com/STEllAR-GROUP/hpx/issues/5799
-    conflicts("+kokkos ^kokkos@4.1.00: +cuda +hpx", when="%gcc",
-              msg=("Using hpx sender/receiver backend (kokkos@4.1.0:) with nvcc does not work."
-                   "Use clang or downgrade Kokkos, or deactivate +hpx"))
+    # conflicts("+kokkos ^kokkos@4.1.00: +cuda +hpx", when="%gcc",
+     #          msg=("Using hpx sender/receiver backend (kokkos@4.1.0:) with nvcc does not work."
+      #              "Use clang or downgrade Kokkos, or deactivate +hpx"))
     conflicts("%gcc@12", when="@0.8.0",
             msg="Octotiger release 0.8.0 does not work with gcc@12 - try an older one!")
     conflicts("+cuda", when="cuda_arch=none")


### PR DESCRIPTION
This PR adapts the conflicts on constraints to allow using gcc/nvcc and the Kokkos HPX execution when using Kokkos develop and HPX master (was broken due to compilation crashes from Kokkos 4.1.00 onward previously). The PR also backports the respective fixes via patches to some older HPX and Kokkos releases.

Will stay as a draft PR until the respective HPX and Kokkos PRs are merged first.