### PR TITLE
Allow using HPX execution space with nvcc builds with newer HPX/Kokkos versions

### DIFF
--- a/packages/cppuddle/package.py
+++ b/packages/cppuddle/package.py
@@ -57,6 +57,7 @@ class Cppuddle(CMakePackage):
     depends_on("cuda", when="+enable_gpu_tests")
 
     conflicts("+enable_gpu_tests", when="~hpx")
+    conflicts("@:0.3.1", when="%gcc@14:", msg="User newer CPPuddle with GCC >= 14")
 
     build_directory = "spack-build"
 

--- a/packages/kokkos-nvcc-wrapper/package.py
+++ b/packages/kokkos-nvcc-wrapper/package.py
@@ -19,6 +19,11 @@ class KokkosNvccWrapper(Package):
 
     maintainers("Rombur")
 
+    version("4.3.01", sha256="5998b7c732664d6b5e219ccc445cd3077f0e3968b4be480c29cd194b4f45ec70")
+    version("4.3.00", sha256="53cf30d3b44dade51d48efefdaee7a6cf109a091b702a443a2eda63992e5fe0d")
+    version("4.2.01", sha256="cbabbabba021d00923fb357d2e1b905dda3838bd03c885a6752062fe03c67964")
+    version("4.2.00", sha256="ac08765848a0a6ac584a0a46cd12803f66dd2a2c2db99bb17c06ffc589bf5be8")
+    version("4.1.00", sha256="cf725ea34ba766fdaf29c884cfe2daacfdc6dc2d6af84042d1c78d0f16866275")
     version("4.0.01", sha256="bb942de8afdd519fd6d5d3974706bfc22b6585a62dd565c12e53bdb82cd154f0")
     version("4.0.00", sha256="1829a423883d4b44223c7c3a53d3c51671145aad57d7d23e6a1a4bebf710dcf6")
     version("3.7.02", sha256="5024979f06bc8da2fb696252a66297f3e0e67098595a0cc7345312b3b4aa0f54")
@@ -41,7 +46,8 @@ class KokkosNvccWrapper(Package):
 
     depends_on("cuda")
 
-    patch("adapt-kokkos-for-nix.patch")
+    # TODO is this required anymore?
+    patch("adapt-kokkos-for-nix.patch", when="@:4.1.00")
 
     def install(self, spec, prefix):
         src = os.path.join("bin", "nvcc_wrapper")

--- a/packages/octotiger/package.py
+++ b/packages/octotiger/package.py
@@ -170,9 +170,18 @@ class Octotiger(CMakePackage, CudaPackage, ROCmPackage):
     # Known conflicts
 
     # See issue https://github.com/STEllAR-GROUP/hpx/issues/5799
-    conflicts("+kokkos ^kokkos@4.1.00: +cuda +hpx", when="%gcc",
-              msg=("Using hpx sender/receiver backend (kokkos@4.1.0:) with nvcc does not work."
-                   "Use clang or downgrade Kokkos, or deactivate +hpx"))
+    # Resolver in Kokkos develop (later than 4.3.01) and HPX master (later than 1.9.1)
+    # TODO Move conflicts to Kokkos package.py?
+    conflicts("+kokkos ^kokkos@4.1.00:4.3.01 +cuda +hpx ", when="%gcc",
+              msg=("Using hpx sender/receiver backend with nvcc does not work. "
+                  "Use clang or use a newer (than 4.3.01) or older (than 4.1.00) Kokkos version, or deactivate +hpx"))
+    conflicts("+kokkos ^kokkos@4.1.00: +cuda +hpx %gcc ", when="^cuda@:12.2.1",
+              msg=("Using hpx sender/receiver backend with nvcc does not work with older (than 12.3.0) CUDA versions. "
+                  "Use clang or use a newer (than 4.3.01) or older (than 4.1.00) Kokkos version, or deactivate +hpx"))
+    conflicts("+kokkos ^hpx@:1.9.1 ", when="%gcc ^kokkos@4.1.00:",
+              msg=("Using hpx sender/receiver backend with nvcc does not work. "
+                   "Use clang or use a newer (than 1.9.1) HPX version, or deactivate +hpx in kokkos"))
+
     conflicts("%gcc@12", when="@0.8.0",
             msg="Octotiger release 0.8.0 does not work with gcc@12 - try an older one!")
     conflicts("+cuda", when="cuda_arch=none")


### PR DESCRIPTION
This PR adapts the conflicts on constraints to allow using gcc/nvcc and the Kokkos HPX execution when using Kokkos develop and HPX master (was broken due to compilation crashes from Kokkos 4.1.00 onward previously). 

Replaces #10 which was also attempting to backport the fixes to older HPX and Kokkos releases (which this PR does not).